### PR TITLE
PV move overwritten by TT

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -280,6 +280,11 @@ int pvSearch(Board *board, int depth, int alpha, int beta, const int nullmove) {
 		flag = LOWER_BOUND;
 
 	// Always replace the entry for the TT
+	// UNLESS the position currently in there has a different key and goes deeper
+	if (tt[index].key != board->key && tt[index].depth > depth) {
+		return bestScore;
+	}
+
 	tt[index] = compressEntry(board->key, &bestMove, bestScore, depth, flag);
 
 	return bestScore;


### PR DESCRIPTION
Resolves #2, which is not related to draw detection at all, but due to the possibly of the current board's hash table key matching that of a board in a future variation and being overwritten by default. The fix is to check for conflicting hash keys, and preferring the board with the higher depth.
A test of 500 games of 10+0.1 seconds shows the change is unlikely to have a big impact on play strength. Throughout the entire test, there were few instances where the win-loss difference between the two was more than a small handful of games.
```
Score of Achillees-tt-patch vs Achillees-master: 166 - 168 - 166  [0.498] 500
...      Achillees-tt-patch playing White: 85 - 77 - 88  [0.516] 250
...      Achillees-tt-patch playing Black: 81 - 91 - 78  [0.480] 250
...      White vs Black: 176 - 158 - 166  [0.518] 500
Elo difference: -1.4 +/- 24.9, LOS: 45.6 %, DrawRatio: 33.2 %
```